### PR TITLE
Added secret_key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ app/__pycache__/
 app/src/__pycache__/
 tests/__pycache__/
 tests/.pytest_cache
+.env

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -2,12 +2,16 @@ from flask import Flask, render_template
 from flask_login import LoginManager
 from .models import db, User
 from .auth import auth as auth_blueprint
+from dotenv import load_dotenv
+import os
 
+load_dotenv()
 
 app = Flask(__name__)
 
 # Configure and initalize database
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
+app.secret_key = os.getenv('SECRET_KEY')
 
 login_manager = LoginManager()
 login_manager.login_view = 'auth.login'

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -5,6 +5,7 @@ from .auth import auth as auth_blueprint
 from dotenv import load_dotenv
 import os
 
+# load environment variables
 load_dotenv()
 
 app = Flask(__name__)

--- a/app/src/requirements.txt
+++ b/app/src/requirements.txt
@@ -8,3 +8,4 @@ flask_login
 flask_bcrypt
 password_strength
 Werkzeug==2.3.0
+python-dotenv


### PR DESCRIPTION
### IMPORTANT CHANGE!!!
It is CRUCIAL that everybody creates their own .env file in their repository, which stores environment variables. Inside the .env file, assign `SECRET_KEY` to the value in the group chat. IF YOU DO NOT DO THIS, THE APPLICATION WILL NOT RUN.

Changes made:
- Added the secret_key to fix the RuntimeError: the session is unavailable because no secret key was set. Now the error will not appear, and user sessions are secure against potential security threats. The secret key adds security, prevents CSRF (cross-site request forgery), and enables the application to work as intended.
- Added `.env` to the `.gitignore` file, since that file is for reserved environment variables