### PR TITLE
Revert quizSubmit.py filepaths to state before recent PR #117 changes

### DIFF
--- a/app/src/utils/quizSubmit.py
+++ b/app/src/utils/quizSubmit.py
@@ -7,7 +7,7 @@ quiz_api = Blueprint("quiz_api", __name__)
 
 try:
     # Pulling json data from "questions.json"
-    with open("json/questions.json", "r") as f:
+    with open("../json/questions.json", "r") as f:
          data = json.load(f)
          
 except IOError:
@@ -16,7 +16,7 @@ except IOError:
 
 try:
     # Pulling json data from "responses.json"
-    with open("json/responses.json") as f:
+    with open("../json/responses.json") as f:
         listObj = json.load(f)
 
 except IOError:


### PR DESCRIPTION
This is a minor yet important change reverting the file paths in quizSubmit.py (line 10 and 19) to what they were, prior to merging Angad's #117 PR into the main repo. 

Angad's PR happened to contain an older version of the quizSubmit.py file that was revised in later commits (#119), but I didn't realize that upon approving and merging it, the old #117 version would overwrite the revised #119 version. As a result, the server now will not start up properly when running the usual terminal commands (`cd app` -> `flask run --app run_app.py --debug`). Instead, you would have to run `flask run --app app/run_app.py --debug`, which would throw off a lot of people who are used to the version before the merge. This PR just aims to reverse the change, such that the former set of commands can be used again.

This mistake is completely on me, and I'm sorry for the oversight on my part; I should have been more prudent and played things safe by manually updating Angad's quizSubmit.py file before merging his PR.